### PR TITLE
Triangles are now see through by using stroke, fill=none and trigonom…

### DIFF
--- a/css/all-services-pages.css
+++ b/css/all-services-pages.css
@@ -228,7 +228,6 @@ span.emphasized-text {
   left: 0;
   height: 100%;
   width: 100%;
-  pointer-events: none;
 }
 
 .triangle {
@@ -238,7 +237,6 @@ span.emphasized-text {
   left: 0;
   height: 100%;
   width: 100%;
-  pointer-events: none;
 }
 
 .triangle-right-2 {
@@ -247,6 +245,12 @@ span.emphasized-text {
 
 .triangle-left {
   top: 175%;
+}
+
+.polygon-triangle-stroke-color {
+  stroke-width: 0.25;
+  stroke: #f4ce45e8;
+  fill: none;
 }
 
 .workflow {

--- a/information-management.html
+++ b/information-management.html
@@ -74,11 +74,8 @@
           needs of your projects. </p>
       </div>
     </div>
-    <svg class="services-triangle-right hide-on-small-only" width="100%" height="100%" viewBox="0 0 100 100"
-      preserveAspectRatio="none">
-      <polygon points="  100,0   85,50   100,100" fill="#f4ce45e8" /> <!-- yellow -->
-      <polygon points="100.3,0 85.3,50 100.3,50" fill="#eeeeee" /> <!-- eeeeee -->
-      <polygon points="100.3,100 85.3,50 100.3,50" fill="#1c1a18" /> <!-- gray -->
+    <svg class="services-triangle-right hide-on-small-only" viewBox="0 0 100 100" preserveAspectRatio="none">
+      <polygon class="polygon-triangle-stroke-color" points="100,0 100,100 85,50" stroke-dasharray="0 100 21.2132" />
     </svg>
   </div>
   <div class="grey-block">
@@ -96,10 +93,8 @@
           plans, processes and procedures, which then enables a progressive handover, rather than a massive end of
           project task.</p>
         <hr>
-        <svg class="triangle triangle-left hide-on-small-only" width="100%" height="100%" viewBox="0 0 100 100"
-          preserveAspectRatio="none">
-          <polygon points="0,0 15,50 0,100" fill="#f4ce45e8" /> <!-- yellow -->
-          <polygon points="-0.3,100 14.7,50 -0.3,0" fill="#1c1a18" /> <!-- gray -->
+        <svg class="triangle triangle-left hide-on-small-only" viewBox="0 0 100 100" preserveAspectRatio="none" >
+          <polygon class="polygon-triangle-stroke-color" points="0,0 0,100 15,50" stroke-dasharray="0 100 21.2132"/>
         </svg>
         <h3>Electronic Document Management Systems</h3>
         <p>Our team has experience of over 15 of the industry leading EDMS at an administrator and developer level,
@@ -124,10 +119,8 @@
   <div class="black-block">
     <div class="service-block">
       <div class="container">
-        <svg class="triangle triangle-right-2 hide-on-small-only" width="100%" height="100%" viewBox="0 0 100 100"
-          preserveAspectRatio="none">
-          <polygon points="  100,0   85,50   100,100" fill="#f4ce45e8" /> <!-- yellow -->
-          <polygon points="100.3,0 85.3,50 100.3,100" fill="#1c1a18" /> <!-- gray -->
+        <svg class="triangle triangle-right-2 hide-on-small-only" viewBox="0 0 100 100" preserveAspectRatio="none">
+          <polygon class="polygon-triangle-stroke-color" points="100,0 100,100 85,50" stroke-dasharray="0 100 21.2132" />
         </svg>
         <h3>Document Management Plans</h3>
         <p>Our team has experience authoring, reviewing, approving and implementing document management across

--- a/operations-maintenance.html
+++ b/operations-maintenance.html
@@ -77,28 +77,15 @@
         </p>
       </div>
     </div>
-    <svg
-      class="services-triangle-right hide-on-small-only"
-      width="100%"
-      height="100%"
-      viewBox="0 0 100 100"
-      preserveAspectRatio="none"
-    >
-      <polygon points="  100,0   85,50   100,100" fill="#f4ce45e8" />
-      <!-- yellow -->
-      <polygon points="100.3,0 85.3,50 100.3,50" fill="#eeeeee" />
-      <!-- eeeeee -->
-      <polygon points="100.3,100 85.3,50 100.3,50" fill="#1c1a18" />
-      <!-- gray -->
+    <svg class="services-triangle-right hide-on-small-only" viewBox="0 0 100 100" preserveAspectRatio="none" >
+      <polygon class="polygon-triangle-stroke-color" points="100,0 100,100 85,50" stroke-dasharray="0 100 21.2132" />
     </svg>
   </div>
   <div class="grey-block">
     <div class="service-block">
       <div class="container">
-        <svg class="triangle triangle-left hide-on-small-only" width="100%" height="100%" viewBox="0 0 100 100"
-          preserveAspectRatio="none">
-          <polygon points="0,0 15,50 0,100" fill="#f4ce45e8" /> <!-- yellow -->
-          <polygon points="-0.3,100 14.7,50 -0.3,0" fill="#1c1a18" /> <!-- gray -->
+        <svg class="triangle triangle-left hide-on-small-only" viewBox="0 0 100 100" preserveAspectRatio="none">
+          <polygon class="polygon-triangle-stroke-color" points="0,0 0,100 15,50" stroke-dasharray="0 100 21.2132"/>
         </svg>
         <!-- <img class="workflow" src="https://via.placeholder.com/1100x800" alt="Information Management Workflow"> -->
         <p class="margin-top-om">Given the ever-growing scope of information management and its application in leveraging data for increased

--- a/reporting-analytics.html
+++ b/reporting-analytics.html
@@ -112,35 +112,15 @@
           </p>
         </div>
       </div>
-      <svg
-        class="services-triangle-right hide-on-small-only"
-        width="100%"
-        height="100%"
-        viewBox="0 0 100 100"
-        preserveAspectRatio="none"
-      >
-        <polygon points="  100,0   85,50   100,100" fill="#f4ce45e8" />
-        <!-- yellow -->
-        <polygon points="100.3,0 85.3,50 100.3,50" fill="#eeeeee" />
-        <!-- eeeeee -->
-        <polygon points="100.3,100 85.3,50 100.3,50" fill="#1c1a18" />
-        <!-- gray -->
+      <svg class="services-triangle-right hide-on-small-only" viewBox="0 0 100 100" preserveAspectRatio="none" >
+        <polygon class="polygon-triangle-stroke-color" points="100,0 100,100 85,50" stroke-dasharray="0 100 21.2132" />
       </svg>
     </div>
     <div class="grey-block">
       <div class="service-block">
         <div class="container">
-          <svg
-            class="triangle triangle-left hide-on-small-only"
-            width="100%"
-            height="100%"
-            viewBox="0 0 100 100"
-            preserveAspectRatio="none"
-          >
-            <polygon points="0,0 15,50 0,100" fill="#f4ce45e8" />
-            <!-- yellow -->
-            <polygon points="-0.3,100 14.7,50 -0.3,0" fill="#1c1a18" />
-            <!-- gray -->
+          <svg class="triangle triangle-left hide-on-small-only" viewBox="0 0 100 100" preserveAspectRatio="none">
+            <polygon class="polygon-triangle-stroke-color" points="0,0 0,100 15,50" stroke-dasharray="0 100 21.2132"/>
           </svg>
           <img
             src="assets/flowcharts/RA workflow 1_1.svg"


### PR DESCRIPTION
- Services triangles are now see through 
- Removed redudant styling directly on svg elements, 
- Removed the 2 extra triangles per, uh , yellow triangle
- Using a CSS class for stroke styling to match index.html triangles styling.